### PR TITLE
error logging

### DIFF
--- a/pkg/chart/jupyterhub.go
+++ b/pkg/chart/jupyterhub.go
@@ -47,37 +47,37 @@ type jupyterValues struct {
 func (c Client) syncJupyter(ctx context.Context, configurableValues JupyterConfigurableValues, log logger.Logger) error {
 	team, err := c.repo.TeamGet(ctx, configurableValues.TeamID)
 	if err != nil {
-		log.WithError(err).Error("getting team from database")
+		log.WithError(err).Info("getting team from database")
 		return err
 	}
 
 	values, err := c.jupyterMergeValues(ctx, team, configurableValues)
 	if err != nil {
-		log.WithError(err).Error("merging jupyter values")
+		log.WithError(err).Info("merging jupyter values")
 		return err
 	}
 
 	namespace := k8s.TeamIDToNamespace(team.ID)
 
 	if err := c.createHttpRoute(ctx, team.Slug+".jupyter.knada.io", namespace, gensql.ChartTypeJupyterhub); err != nil {
-		log.WithError(err).Error("creating http route")
+		log.WithError(err).Info("creating http route")
 		return err
 	}
 
 	if err := c.createHealtCheckPolicy(ctx, namespace, gensql.ChartTypeJupyterhub); err != nil {
-		log.WithError(err).Error("creating health check policy")
+		log.WithError(err).Info("creating health check policy")
 		return err
 	}
 
 	chartValues, err := reflect.CreateChartValues(values)
 	if err != nil {
-		log.WithError(err).Error("creating chart values")
+		log.WithError(err).Info("creating chart values")
 		return err
 	}
 
 	err = c.repo.HelmChartValuesInsert(ctx, gensql.ChartTypeJupyterhub, chartValues, team.ID)
 	if err != nil {
-		log.WithError(err).Error("inserting helm values to database")
+		log.WithError(err).Info("inserting helm values to database")
 		return err
 	}
 
@@ -135,7 +135,7 @@ func (c Client) jupyterMergeValues(ctx context.Context, team gensql.TeamGetRow, 
 
 func (c Client) deleteJupyter(ctx context.Context, teamID string, log logger.Logger) error {
 	if err := c.repo.ChartDelete(ctx, teamID, gensql.ChartTypeJupyterhub); err != nil {
-		log.WithError(err).Error("delete chart from database")
+		log.WithError(err).Info("delete chart from database")
 		return err
 	}
 
@@ -146,12 +146,12 @@ func (c Client) deleteJupyter(ctx context.Context, teamID string, log logger.Log
 	namespace := k8s.TeamIDToNamespace(teamID)
 
 	if err := c.deleteHttpRoute(ctx, namespace, gensql.ChartTypeJupyterhub); err != nil {
-		log.WithError(err).Error("deleting http route")
+		log.WithError(err).Info("deleting http route")
 		return err
 	}
 
 	if err := c.deleteHealtCheckPolicy(ctx, namespace, gensql.ChartTypeJupyterhub); err != nil {
-		log.WithError(err).Error("deleting health check policy")
+		log.WithError(err).Info("deleting health check policy")
 		return err
 	}
 

--- a/pkg/events/dispatcher.go
+++ b/pkg/events/dispatcher.go
@@ -226,9 +226,9 @@ func (e EventHandler) Run(tickDuration time.Duration) {
 					cancelFuncs = append(cancelFuncs, cancelFunc)
 
 					if err := worker(ctx, event, eventLogger); err != nil {
-						eventLogger.log.WithError(err).Error("failed processing event")
 						if event.RetryCount > 5 {
 							eventLogger.log.Error("event reached max retries")
+							eventLogger.log.WithError(err).Error("failed processing event")
 							if err := e.repo.EventSetStatus(e.context, event.ID, database.EventStatusFailed); err != nil {
 								eventLogger.log.WithError(err).Error("failed setting event status to 'failed'")
 							}

--- a/pkg/events/dispatcher.go
+++ b/pkg/events/dispatcher.go
@@ -226,9 +226,9 @@ func (e EventHandler) Run(tickDuration time.Duration) {
 					cancelFuncs = append(cancelFuncs, cancelFunc)
 
 					if err := worker(ctx, event, eventLogger); err != nil {
+						eventLogger.log.WithError(err).Info("failed processing event")
 						if event.RetryCount > 5 {
-							eventLogger.log.Error("event reached max retries")
-							eventLogger.log.WithError(err).Error("failed processing event")
+							eventLogger.log.WithError(err).Error("failed processing event, reached max retries")
 							if err := e.repo.EventSetStatus(e.context, event.ID, database.EventStatusFailed); err != nil {
 								eventLogger.log.WithError(err).Error("failed setting event status to 'failed'")
 							}

--- a/pkg/user/gsm.go
+++ b/pkg/user/gsm.go
@@ -24,7 +24,7 @@ func (c Client) CreateUserGSM(ctx context.Context, manager gensql.UserGoogleSecr
 func (c Client) createGSM(ctx context.Context, manager gensql.UserGoogleSecretManager, log logger.Logger) (bool, error) {
 	existingInstance, err := c.repo.UserGSMGet(ctx, manager.Owner)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		log.WithError(err).Errorf("failed retrieving User Google Secret Manager %v", manager.Owner)
+		log.WithError(err).Infof("failed retrieving User Google Secret Manager %v", manager.Owner)
 		return true, err
 	}
 
@@ -34,12 +34,12 @@ func (c Client) createGSM(ctx context.Context, manager gensql.UserGoogleSecretMa
 
 	err = c.createUserGSMInGCP(ctx, manager.Name, manager.Owner)
 	if err != nil {
-		log.WithError(err).Error("failed creating User Google Secret Manager in GCP")
+		log.WithError(err).Info("failed creating User Google Secret Manager in GCP")
 		return true, err
 	}
 
 	if err := c.repo.UserGSMCreate(ctx, manager); err != nil {
-		log.WithError(err).Error("failed saving User Google Secret Manager to database")
+		log.WithError(err).Info("failed saving User Google Secret Manager to database")
 		return true, err
 	}
 
@@ -65,17 +65,17 @@ func (c Client) deleteGSM(ctx context.Context, email string, log logger.Logger) 
 			return false, nil
 		}
 
-		log.WithError(err).Error("failed retrieving User Google Secret Manager")
+		log.WithError(err).Info("failed retrieving User Google Secret Manager")
 		return true, err
 	}
 
 	if err := c.deleteUserGSMFromGCP(ctx, instance.Name); err != nil {
-		log.WithError(err).Error("failed deleting User Google Secret Manager from GCP")
+		log.WithError(err).Info("failed deleting User Google Secret Manager from GCP")
 		return true, err
 	}
 
 	if err = c.repo.UserGSMDelete(ctx, email); err != nil {
-		log.WithError(err).Error("failed deleting User Google Secret Manager from database")
+		log.WithError(err).Info("failed deleting User Google Secret Manager from database")
 		return true, err
 	}
 


### PR DESCRIPTION
Slik det er i dag vil alle logginnslag med errornivå som oppstår når knorten håndterer events bli postet til slack som en alert. Da vi er avhengig av en del eksterne apier og tjenester kan det oppstå situasjoner der vi får en feil som så vil fikses seg selv med retry-støtten vi allerede har implementert i knorten. Særlig gjelder dette interaksjoner vi gjør mot google sitt api med gcloud. Her har vi sett fra tid til annen at eksempelvis oppdatering av prosjekt IAM feiler da det forsøkes å gjøres endringer fra to eller flere forskjellige events samtidig. Forslaget med denne PRen er at vi først logger en event som error dersom den har feilet på alle retries. I dag vil Knorten forsøke alle events den håndterer 5 ganger før den gir opp.