### PR TITLE
[NOTASK] Enable linting

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -15,7 +15,7 @@ jobs:
         go-version: '^1.21' # The Go version to download (if necessary) and use.
         check-latest: true
 
-    - run: make test
+    - run: make check
 
     - run: go install honnef.co/go/tools/cmd/staticcheck@latest
     - run: staticcheck ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,9 @@ linters:
     # Linters with dubious value
     - depguard
     - tagalign
+    - tagliatelle
     - goerr113
+    - gci
 
     # These linters find structures with uninitialized fields, which is useful under
     # certain conditions, but shouldn't be generally enabled.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     # Linters that check comments for correctness; disallow fixme, todo, etc., missing punctuation, etc.
     - godox
     - godot
+    - stylecheck
 
     # Linters with dubious value
     - depguard

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,10 @@ linters:
     - varcheck
 
 issues:
+  # Show only new issues created after git revision
+  # A long-term goal should be to fix all existing issues, and then remove this
+  new-from-rev: HEAD
+
   exclude-use-default: false
   exclude-rules:
     - path: (.+)_test.go


### PR DESCRIPTION
There was a lot of things to fix up when enabling golangci-lint. Instead of creating one insanely large PR with everything, and also to get started with linting, we have now set the linter to only look at changes since HEAD. We might want to change this to some git commit in main though, but lets see.

To run the linting locally we have the target: `make lint`