### PR TITLE
feat: ops agent for nye vmer

### DIFF
--- a/pkg/user/gcp.go
+++ b/pkg/user/gcp.go
@@ -42,7 +42,7 @@ func (c Client) createComputeInstanceInGCP(ctx context.Context, instanceName, em
 		"--machine-type", "n2-standard-2",
 		"--network-interface", "network=knada-vpc,subnet=knada,no-address",
 		fmt.Sprintf("--labels=goog-ops-agent-policy=v2-x86-template-1-2-0,created-by=knorten,user=%v", normalizeEmailToName(email)),
-		"--metadata=block-project-ssh-keys=TRUE",
+		"--metadata=block-project-ssh-keys=TRUE,enable-osconfig=TRUE",
 		"--service-account=knada-vm-ops-agent@knada-gcp.iam.gserviceaccount.com",
 		"--no-scopes",
 	)

--- a/pkg/user/gcp.go
+++ b/pkg/user/gcp.go
@@ -41,9 +41,9 @@ func (c Client) createComputeInstanceInGCP(ctx context.Context, instanceName, em
 		"--zone", c.gcpZone,
 		"--machine-type", "n2-standard-2",
 		"--network-interface", "network=knada-vpc,subnet=knada,no-address",
-		fmt.Sprintf("--labels=created-by=knorten,user=%v", normalizeEmailToName(email)),
+		fmt.Sprintf("--labels=goog-ops-agent-policy=v2-x86-template-1-2-0,created-by=knorten,user=%v", normalizeEmailToName(email)),
 		"--metadata=block-project-ssh-keys=TRUE",
-		"--no-service-account",
+		"--service-account=knada-vm-ops-agent@knada-gcp.iam.gserviceaccount.com",
 		"--no-scopes",
 	)
 


### PR DESCRIPTION
Holder med bare en label og SA for å automatisk få satt opp Ops Agent. Det er viktig at vi bruker riktig sone for den labelen jeg har lagt til (den er knyttet til `europe-north1-b`).
https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/install-agent-vm-creation