### PR TITLE
set default kubectl container

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: knorten
+      annotations:
+        kubectl.kubernetes.io/default-container: knorten
     spec:
       serviceAccountName: knorten
       containers:


### PR DESCRIPTION
to avoid having to specify container when reading logs from main container in cluster